### PR TITLE
Add glib-networking to projects to examine

### DIFF
--- a/projects_to_examine.csv
+++ b/projects_to_examine.csv
@@ -66,6 +66,7 @@ gcc-4.7,,gcc,gcc,, GNU C compiler,Standard System Utilities,0,0,0,,
 gcc-4.7-base,gcc-4.7,gcc,gcc,," GCC, the GNU Compiler Collection (base package)",Standard System Utilities,0,0,0,,
 geoip-database,,geoipdb,geoipdb,, IP lookup command line tools that use the GeoIP library (country database),Standard System Utilities,1,0,0,,
 gettext-base,gettext,gettext,gettext,, GNU Internationalization utilities for the base system,Standard System Utilities,0,0,0,,
+glib-networking,,glib-networking,glib-networking,https://bugzilla.gnome.org/buglist.cgi?quicksearch=component:network product:"glib", network-related giomodules for GLib,???,1,0,0,TLS API. Implements its own certificate verification. No support for certificate revocation. No active developers.,Implements GLib's TLS API, most notably used by libsoup (used by all GNOME applications, WebKitGTK+, etc.). It uses GnuTLS internally.
 gnupg,,gnupg,gnupg,, GNU privacy guard - a free PGP replacement,Standard System Utilities,0,1,0,Vital for protecting email (CII has already invested with a one-time investment) ++,
 gpgv,gnupg, gnupg,gnupg,, GNU privacy guard - signature verification tool,Standard System Utilities,0,1,0,Vital for protecting email (CII has already invested with a one-time investment) ++,
 grep,,grep,grep,," GNU grep, egrep and fgrep",Standard System Utilities,0,0,0,,


### PR DESCRIPTION
Hi, I suggest monitoring glib-networking, since it implements certificate verification for tons of applications but has low upstream activity and several known issues (for example, [it rejects certificate chains that GnuTLS normally accepts](https://bugzilla.gnome.org/show_bug.cgi?id=750457), and [it doesn't support any form certificate revocation checking](https://bugzilla.gnome.org/show_bug.cgi?id=728141)).

Notes:

* I added a link to the bugtracker, but it is the first one not a GitHub issue tracker. Not sure if that will mess up any scripts that process this.
* I just made up the cve_keyword. I presume that's just the search term used to look for CVEs?
* I have no clue what Debian installation group it's in so I marked that ???. Maybe you have some easy way to figure that out. I found the other Debian-specific information on https://packages.debian.org/jessie/glib-networking